### PR TITLE
logpaths for puppet

### DIFF
--- a/syslog-ng.conf.d/destination.d/puppet-agent.conf
+++ b/syslog-ng.conf.d/destination.d/puppet-agent.conf
@@ -1,0 +1,3 @@
+# puppet-agent destination
+
+destination d_puppet_agent { file("`syslog_dir`/puppet-agent.log"); };

--- a/syslog-ng.conf.d/destination.d/puppet-master.conf
+++ b/syslog-ng.conf.d/destination.d/puppet-master.conf
@@ -1,0 +1,3 @@
+# puppet-master destination
+
+destination d_puppet_master { file("`syslog_dir`/puppet-master.log"); };

--- a/syslog-ng.conf.d/filter.d/puppet-agent.conf
+++ b/syslog-ng.conf.d/filter.d/puppet-agent.conf
@@ -1,0 +1,3 @@
+# puppet-agent filter
+
+filter f_puppet_agent { program("puppet-agent"); };

--- a/syslog-ng.conf.d/filter.d/puppet-master.conf
+++ b/syslog-ng.conf.d/filter.d/puppet-master.conf
@@ -1,0 +1,3 @@
+# puppet-master filter
+
+filter f_puppet_master { program("puppet-master"); };

--- a/syslog-ng.conf.d/log.d/90_puppet-agent.conf
+++ b/syslog-ng.conf.d/log.d/90_puppet-agent.conf
@@ -1,0 +1,3 @@
+# puppet-agent default final log file
+
+log { source(s_log); filter(f_puppet_agent); destination(d_puppet_agent); flags(final); };

--- a/syslog-ng.conf.d/log.d/90_puppet-master.conf
+++ b/syslog-ng.conf.d/log.d/90_puppet-master.conf
@@ -1,0 +1,3 @@
+# puppet-master default final log file
+
+log { source(s_log); filter(f_puppet_master); destination(d_puppet_master); flags(final); };


### PR DESCRIPTION
These are logpaths for puppet agents and masters.

@paraenggu Let me know if you want me to split agent and master into two seperate logpaths. I'm not sure how it's meant to be (one could argue for both cases).
