### PR TITLE
Implement new permissions

### DIFF
--- a/syslog-ng.conf
+++ b/syslog-ng.conf
@@ -20,9 +20,9 @@
 @define syslog_dir "`log_base_dir`/syslog"
 
 # default owner, group and permissions of output files.
-@define owner "root"
-@define group "log"
-@define perm 0640
+@define default_log_owner "root"
+@define default_log_group "log"
+@define default_log_perm 0640
 
 # include base directory
 @define include_base_dir "/etc/syslog-ng/syslog-ng.conf.d"

--- a/syslog-ng.conf
+++ b/syslog-ng.conf
@@ -19,6 +19,11 @@
 @define log_base_dir "/var/log"
 @define syslog_dir "`log_base_dir`/syslog"
 
+# default owner, group and permissions of output files.
+@define owner "root"
+@define group "log"
+@define perm 0640
+
 # include base directory
 @define include_base_dir "/etc/syslog-ng/syslog-ng.conf.d"
 

--- a/syslog-ng.conf.d/option.d/default.conf
+++ b/syslog-ng.conf.d/option.d/default.conf
@@ -4,4 +4,7 @@ options {
   flush_lines(0);
   log_fifo_size(10000);
   stats_freq(43200);
+  owner("`owner`");
+  group("`group`");
+  perm(`perm`);
 };

--- a/syslog-ng.conf.d/option.d/default.conf
+++ b/syslog-ng.conf.d/option.d/default.conf
@@ -4,7 +4,7 @@ options {
   flush_lines(0);
   log_fifo_size(10000);
   stats_freq(43200);
-  owner("`owner`");
-  group("`group`");
-  perm(`perm`);
+  owner("`default_log_owner`");
+  group("`default_log_group`");
+  perm(`default_log_perm`);
 };


### PR DESCRIPTION
Implement new permissions for syslog-ng. Set the following permissions to log output files:

owner: root
group: log
permissions: 0640
